### PR TITLE
`feat`: Add proto oneof msgs for program & allow folder structure change

### DIFF
--- a/packages/renderers-vixen-parser/e2e/generate-anchor.cjs
+++ b/packages/renderers-vixen-parser/e2e/generate-anchor.cjs
@@ -46,8 +46,11 @@ async function generateProject(project, sdkName, generateProto) {
     const projectName = visit(
         node,
         renderVisitor(path.join(__dirname, project, 'parser'), {
+            cargoAdditionalDependencies: [
+                `codama-renderers-rust-e2e-${project} = { path = "../../../../renderers-rust/e2e/${project}" }`,
+            ],
             sdkName: sdkName,
-            project: project,
+            project: `codama-renderers-vixen-parser-e2e-${project}`,
             generateProto: generateProto,
             crateFolder: path.join(__dirname, project, 'parser'),
             formatCode: true,

--- a/packages/renderers-vixen-parser/e2e/meteora/parser/Cargo.toml
+++ b/packages/renderers-vixen-parser/e2e/meteora/parser/Cargo.toml
@@ -8,12 +8,11 @@ edition = "2021"
 
 [dependencies]
 prost = "0.13.1"
-prost-build = { version = "0.13.1"}
 yellowstone-vixen-core = { git = "https://github.com/rpcpool/yellowstone-vixen", branch = "main",features = ["proto"]}
 tonic = { version = "0.12.1", features = ["gzip", "zstd"] }
-codama-renderers-rust-e2e-meteora = { path = "../../../../renderers-rust/e2e/meteora" }
 solana-program = "^2.1.6"
 borsh = "^0.10"
+codama-renderers-rust-e2e-meteora = { path = "../../../../renderers-rust/e2e/meteora" }
 
 
 

--- a/packages/renderers-vixen-parser/e2e/meteora/parser/proto/proto_def.proto
+++ b/packages/renderers-vixen-parser/e2e/meteora/parser/proto/proto_def.proto
@@ -1160,3 +1160,62 @@ message SetPreActivationSwapAddressIxData {
 }
 
 
+message LbClmmProgramState {
+  oneof state_oneof {
+            	BinArrayBitmapExtension bin_array_bitmap_extension = 1;
+            	BinArray bin_array = 2;
+            	LbPair lb_pair = 3;
+            	Oracle oracle = 4;
+            	Position position = 5;
+            	PositionV2 position_v2 = 6;
+            	PresetParameter preset_parameter = 7;
+      }
+}
+
+message LbClmmIxs {
+  oneof ix_oneof {
+            	InitializeLbPairIx initialize_lb_pair = 1;
+            	InitializePermissionLbPairIx initialize_permission_lb_pair = 2;
+            	InitializeCustomizablePermissionlessLbPairIx initialize_customizable_permissionless_lb_pair = 3;
+            	InitializeBinArrayBitmapExtensionIx initialize_bin_array_bitmap_extension = 4;
+            	InitializeBinArrayIx initialize_bin_array = 5;
+            	AddLiquidityIx add_liquidity = 6;
+            	AddLiquidityByWeightIx add_liquidity_by_weight = 7;
+            	AddLiquidityByStrategyIx add_liquidity_by_strategy = 8;
+            	AddLiquidityByStrategyOneSideIx add_liquidity_by_strategy_one_side = 9;
+            	AddLiquidityOneSideIx add_liquidity_one_side = 10;
+            	RemoveLiquidityIx remove_liquidity = 11;
+            	InitializePositionIx initialize_position = 12;
+            	InitializePositionPdaIx initialize_position_pda = 13;
+            	InitializePositionByOperatorIx initialize_position_by_operator = 14;
+            	UpdatePositionOperatorIx update_position_operator = 15;
+            	SwapIx swap = 16;
+            	SwapExactOutIx swap_exact_out = 17;
+            	SwapWithPriceImpactIx swap_with_price_impact = 18;
+            	WithdrawProtocolFeeIx withdraw_protocol_fee = 19;
+            	InitializeRewardIx initialize_reward = 20;
+            	FundRewardIx fund_reward = 21;
+            	UpdateRewardFunderIx update_reward_funder = 22;
+            	UpdateRewardDurationIx update_reward_duration = 23;
+            	ClaimRewardIx claim_reward = 24;
+            	ClaimFeeIx claim_fee = 25;
+            	ClosePositionIx close_position = 26;
+            	UpdateFeeParametersIx update_fee_parameters = 27;
+            	IncreaseOracleLengthIx increase_oracle_length = 28;
+            	InitializePresetParameterIx initialize_preset_parameter = 29;
+            	ClosePresetParameterIx close_preset_parameter = 30;
+            	RemoveAllLiquidityIx remove_all_liquidity = 31;
+            	TogglePairStatusIx toggle_pair_status = 32;
+            	MigratePositionIx migrate_position = 33;
+            	MigrateBinArrayIx migrate_bin_array = 34;
+            	UpdateFeesAndRewardsIx update_fees_and_rewards = 35;
+            	WithdrawIneligibleRewardIx withdraw_ineligible_reward = 36;
+            	SetActivationPointIx set_activation_point = 37;
+            	RemoveLiquidityByRangeIx remove_liquidity_by_range = 38;
+            	AddLiquidityOneSidePreciseIx add_liquidity_one_side_precise = 39;
+            	GoToABinIx go_to_a_bin = 40;
+            	SetPreActivationDurationIx set_pre_activation_duration = 41;
+            	SetPreActivationSwapAddressIx set_pre_activation_swap_address = 42;
+      }
+}
+

--- a/packages/renderers-vixen-parser/e2e/meteora/parser/src/generated/instructions_parser.rs
+++ b/packages/renderers-vixen-parser/e2e/meteora/parser/src/generated/instructions_parser.rs
@@ -206,6 +206,96 @@ impl InstructionParser {
         let ix_discriminator: [u8; 8] = ix.data[0..8].try_into()?;
         let mut ix_data = &ix.data[8..];
         match ix_discriminator {
+            [45, 154, 237, 210, 221, 15, 166, 92] => {
+                check_min_accounts_req(accounts_len, 14)?;
+                let ix_accounts = InitializeLbPairIxAccounts {
+                    lb_pair: ix.accounts[0].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[1]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[1].0.into())
+                    },
+                    token_mint_x: ix.accounts[2].0.into(),
+                    token_mint_y: ix.accounts[3].0.into(),
+                    reserve_x: ix.accounts[4].0.into(),
+                    reserve_y: ix.accounts[5].0.into(),
+                    oracle: ix.accounts[6].0.into(),
+                    preset_parameter: ix.accounts[7].0.into(),
+                    funder: ix.accounts[8].0.into(),
+                    token_program: ix.accounts[9].0.into(),
+                    system_program: ix.accounts[10].0.into(),
+                    rent: ix.accounts[11].0.into(),
+                    event_authority: ix.accounts[12].0.into(),
+                    program: ix.accounts[13].0.into(),
+                };
+                let de_ix_data: InitializeLbPairIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::InitializeLbPair(ix_accounts, de_ix_data))
+            }
+            [108, 102, 213, 85, 251, 3, 53, 21] => {
+                check_min_accounts_req(accounts_len, 14)?;
+                let ix_accounts = InitializePermissionLbPairIxAccounts {
+                    base: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    token_mint_x: ix.accounts[3].0.into(),
+                    token_mint_y: ix.accounts[4].0.into(),
+                    reserve_x: ix.accounts[5].0.into(),
+                    reserve_y: ix.accounts[6].0.into(),
+                    oracle: ix.accounts[7].0.into(),
+                    admin: ix.accounts[8].0.into(),
+                    token_program: ix.accounts[9].0.into(),
+                    system_program: ix.accounts[10].0.into(),
+                    rent: ix.accounts[11].0.into(),
+                    event_authority: ix.accounts[12].0.into(),
+                    program: ix.accounts[13].0.into(),
+                };
+                let de_ix_data: InitializePermissionLbPairIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::InitializePermissionLbPair(
+                    ix_accounts,
+                    de_ix_data,
+                ))
+            }
+            [46, 39, 41, 135, 111, 183, 200, 64] => {
+                check_min_accounts_req(accounts_len, 14)?;
+                let ix_accounts = InitializeCustomizablePermissionlessLbPairIxAccounts {
+                    lb_pair: ix.accounts[0].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[1]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[1].0.into())
+                    },
+                    token_mint_x: ix.accounts[2].0.into(),
+                    token_mint_y: ix.accounts[3].0.into(),
+                    reserve_x: ix.accounts[4].0.into(),
+                    reserve_y: ix.accounts[5].0.into(),
+                    oracle: ix.accounts[6].0.into(),
+                    user_token_x: ix.accounts[7].0.into(),
+                    funder: ix.accounts[8].0.into(),
+                    token_program: ix.accounts[9].0.into(),
+                    system_program: ix.accounts[10].0.into(),
+                    rent: ix.accounts[11].0.into(),
+                    event_authority: ix.accounts[12].0.into(),
+                    program: ix.accounts[13].0.into(),
+                };
+                let de_ix_data: InitializeCustomizablePermissionlessLbPairIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::InitializeCustomizablePermissionlessLbPair(
+                    ix_accounts,
+                    de_ix_data,
+                ))
+            }
             [47, 157, 226, 180, 12, 240, 33, 71] => {
                 check_min_accounts_req(accounts_len, 5)?;
                 let ix_accounts = InitializeBinArrayBitmapExtensionIxAccounts {
@@ -230,6 +320,189 @@ impl InstructionParser {
                 let de_ix_data: InitializeBinArrayIxData =
                     BorshDeserialize::deserialize(&mut ix_data)?;
                 Ok(LbClmmProgramIx::InitializeBinArray(ix_accounts, de_ix_data))
+            }
+            [181, 157, 89, 67, 143, 182, 52, 72] => {
+                check_min_accounts_req(accounts_len, 16)?;
+                let ix_accounts = AddLiquidityIxAccounts {
+                    position: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    user_token_x: ix.accounts[3].0.into(),
+                    user_token_y: ix.accounts[4].0.into(),
+                    reserve_x: ix.accounts[5].0.into(),
+                    reserve_y: ix.accounts[6].0.into(),
+                    token_x_mint: ix.accounts[7].0.into(),
+                    token_y_mint: ix.accounts[8].0.into(),
+                    bin_array_lower: ix.accounts[9].0.into(),
+                    bin_array_upper: ix.accounts[10].0.into(),
+                    sender: ix.accounts[11].0.into(),
+                    token_x_program: ix.accounts[12].0.into(),
+                    token_y_program: ix.accounts[13].0.into(),
+                    event_authority: ix.accounts[14].0.into(),
+                    program: ix.accounts[15].0.into(),
+                };
+                let de_ix_data: AddLiquidityIxData = BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::AddLiquidity(ix_accounts, de_ix_data))
+            }
+            [28, 140, 238, 99, 231, 162, 21, 149] => {
+                check_min_accounts_req(accounts_len, 16)?;
+                let ix_accounts = AddLiquidityByWeightIxAccounts {
+                    position: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    user_token_x: ix.accounts[3].0.into(),
+                    user_token_y: ix.accounts[4].0.into(),
+                    reserve_x: ix.accounts[5].0.into(),
+                    reserve_y: ix.accounts[6].0.into(),
+                    token_x_mint: ix.accounts[7].0.into(),
+                    token_y_mint: ix.accounts[8].0.into(),
+                    bin_array_lower: ix.accounts[9].0.into(),
+                    bin_array_upper: ix.accounts[10].0.into(),
+                    sender: ix.accounts[11].0.into(),
+                    token_x_program: ix.accounts[12].0.into(),
+                    token_y_program: ix.accounts[13].0.into(),
+                    event_authority: ix.accounts[14].0.into(),
+                    program: ix.accounts[15].0.into(),
+                };
+                let de_ix_data: AddLiquidityByWeightIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::AddLiquidityByWeight(
+                    ix_accounts,
+                    de_ix_data,
+                ))
+            }
+            [7, 3, 150, 127, 148, 40, 61, 200] => {
+                check_min_accounts_req(accounts_len, 16)?;
+                let ix_accounts = AddLiquidityByStrategyIxAccounts {
+                    position: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    user_token_x: ix.accounts[3].0.into(),
+                    user_token_y: ix.accounts[4].0.into(),
+                    reserve_x: ix.accounts[5].0.into(),
+                    reserve_y: ix.accounts[6].0.into(),
+                    token_x_mint: ix.accounts[7].0.into(),
+                    token_y_mint: ix.accounts[8].0.into(),
+                    bin_array_lower: ix.accounts[9].0.into(),
+                    bin_array_upper: ix.accounts[10].0.into(),
+                    sender: ix.accounts[11].0.into(),
+                    token_x_program: ix.accounts[12].0.into(),
+                    token_y_program: ix.accounts[13].0.into(),
+                    event_authority: ix.accounts[14].0.into(),
+                    program: ix.accounts[15].0.into(),
+                };
+                let de_ix_data: AddLiquidityByStrategyIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::AddLiquidityByStrategy(
+                    ix_accounts,
+                    de_ix_data,
+                ))
+            }
+            [41, 5, 238, 175, 100, 225, 6, 205] => {
+                check_min_accounts_req(accounts_len, 12)?;
+                let ix_accounts = AddLiquidityByStrategyOneSideIxAccounts {
+                    position: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    user_token: ix.accounts[3].0.into(),
+                    reserve: ix.accounts[4].0.into(),
+                    token_mint: ix.accounts[5].0.into(),
+                    bin_array_lower: ix.accounts[6].0.into(),
+                    bin_array_upper: ix.accounts[7].0.into(),
+                    sender: ix.accounts[8].0.into(),
+                    token_program: ix.accounts[9].0.into(),
+                    event_authority: ix.accounts[10].0.into(),
+                    program: ix.accounts[11].0.into(),
+                };
+                let de_ix_data: AddLiquidityByStrategyOneSideIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::AddLiquidityByStrategyOneSide(
+                    ix_accounts,
+                    de_ix_data,
+                ))
+            }
+            [94, 155, 103, 151, 70, 95, 220, 165] => {
+                check_min_accounts_req(accounts_len, 12)?;
+                let ix_accounts = AddLiquidityOneSideIxAccounts {
+                    position: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    user_token: ix.accounts[3].0.into(),
+                    reserve: ix.accounts[4].0.into(),
+                    token_mint: ix.accounts[5].0.into(),
+                    bin_array_lower: ix.accounts[6].0.into(),
+                    bin_array_upper: ix.accounts[7].0.into(),
+                    sender: ix.accounts[8].0.into(),
+                    token_program: ix.accounts[9].0.into(),
+                    event_authority: ix.accounts[10].0.into(),
+                    program: ix.accounts[11].0.into(),
+                };
+                let de_ix_data: AddLiquidityOneSideIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::AddLiquidityOneSide(
+                    ix_accounts,
+                    de_ix_data,
+                ))
+            }
+            [80, 85, 209, 72, 24, 206, 177, 108] => {
+                check_min_accounts_req(accounts_len, 16)?;
+                let ix_accounts = RemoveLiquidityIxAccounts {
+                    position: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    user_token_x: ix.accounts[3].0.into(),
+                    user_token_y: ix.accounts[4].0.into(),
+                    reserve_x: ix.accounts[5].0.into(),
+                    reserve_y: ix.accounts[6].0.into(),
+                    token_x_mint: ix.accounts[7].0.into(),
+                    token_y_mint: ix.accounts[8].0.into(),
+                    bin_array_lower: ix.accounts[9].0.into(),
+                    bin_array_upper: ix.accounts[10].0.into(),
+                    sender: ix.accounts[11].0.into(),
+                    token_x_program: ix.accounts[12].0.into(),
+                    token_y_program: ix.accounts[13].0.into(),
+                    event_authority: ix.accounts[14].0.into(),
+                    program: ix.accounts[15].0.into(),
+                };
+                let de_ix_data: RemoveLiquidityIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::RemoveLiquidity(ix_accounts, de_ix_data))
             }
             [219, 192, 234, 71, 190, 191, 102, 80] => {
                 check_min_accounts_req(accounts_len, 8)?;
@@ -300,6 +573,112 @@ impl InstructionParser {
                 let de_ix_data: UpdatePositionOperatorIxData =
                     BorshDeserialize::deserialize(&mut ix_data)?;
                 Ok(LbClmmProgramIx::UpdatePositionOperator(
+                    ix_accounts,
+                    de_ix_data,
+                ))
+            }
+            [248, 198, 158, 145, 225, 117, 135, 200] => {
+                check_min_accounts_req(accounts_len, 15)?;
+                let ix_accounts = SwapIxAccounts {
+                    lb_pair: ix.accounts[0].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[1]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[1].0.into())
+                    },
+                    reserve_x: ix.accounts[2].0.into(),
+                    reserve_y: ix.accounts[3].0.into(),
+                    user_token_in: ix.accounts[4].0.into(),
+                    user_token_out: ix.accounts[5].0.into(),
+                    token_x_mint: ix.accounts[6].0.into(),
+                    token_y_mint: ix.accounts[7].0.into(),
+                    oracle: ix.accounts[8].0.into(),
+                    host_fee_in: if ix.accounts[9]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[9].0.into())
+                    },
+                    user: ix.accounts[10].0.into(),
+                    token_x_program: ix.accounts[11].0.into(),
+                    token_y_program: ix.accounts[12].0.into(),
+                    event_authority: ix.accounts[13].0.into(),
+                    program: ix.accounts[14].0.into(),
+                };
+                let de_ix_data: SwapIxData = BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::Swap(ix_accounts, de_ix_data))
+            }
+            [250, 73, 101, 33, 38, 207, 75, 184] => {
+                check_min_accounts_req(accounts_len, 15)?;
+                let ix_accounts = SwapExactOutIxAccounts {
+                    lb_pair: ix.accounts[0].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[1]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[1].0.into())
+                    },
+                    reserve_x: ix.accounts[2].0.into(),
+                    reserve_y: ix.accounts[3].0.into(),
+                    user_token_in: ix.accounts[4].0.into(),
+                    user_token_out: ix.accounts[5].0.into(),
+                    token_x_mint: ix.accounts[6].0.into(),
+                    token_y_mint: ix.accounts[7].0.into(),
+                    oracle: ix.accounts[8].0.into(),
+                    host_fee_in: if ix.accounts[9]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[9].0.into())
+                    },
+                    user: ix.accounts[10].0.into(),
+                    token_x_program: ix.accounts[11].0.into(),
+                    token_y_program: ix.accounts[12].0.into(),
+                    event_authority: ix.accounts[13].0.into(),
+                    program: ix.accounts[14].0.into(),
+                };
+                let de_ix_data: SwapExactOutIxData = BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::SwapExactOut(ix_accounts, de_ix_data))
+            }
+            [56, 173, 230, 208, 173, 228, 156, 205] => {
+                check_min_accounts_req(accounts_len, 15)?;
+                let ix_accounts = SwapWithPriceImpactIxAccounts {
+                    lb_pair: ix.accounts[0].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[1]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[1].0.into())
+                    },
+                    reserve_x: ix.accounts[2].0.into(),
+                    reserve_y: ix.accounts[3].0.into(),
+                    user_token_in: ix.accounts[4].0.into(),
+                    user_token_out: ix.accounts[5].0.into(),
+                    token_x_mint: ix.accounts[6].0.into(),
+                    token_y_mint: ix.accounts[7].0.into(),
+                    oracle: ix.accounts[8].0.into(),
+                    host_fee_in: if ix.accounts[9]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[9].0.into())
+                    },
+                    user: ix.accounts[10].0.into(),
+                    token_x_program: ix.accounts[11].0.into(),
+                    token_y_program: ix.accounts[12].0.into(),
+                    event_authority: ix.accounts[13].0.into(),
+                    program: ix.accounts[14].0.into(),
+                };
+                let de_ix_data: SwapWithPriceImpactIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::SwapWithPriceImpact(
                     ix_accounts,
                     de_ix_data,
                 ))
@@ -492,6 +871,34 @@ impl InstructionParser {
                 };
                 Ok(LbClmmProgramIx::ClosePresetParameter(ix_accounts))
             }
+            [10, 51, 61, 35, 112, 105, 24, 85] => {
+                check_min_accounts_req(accounts_len, 16)?;
+                let ix_accounts = RemoveAllLiquidityIxAccounts {
+                    position: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    user_token_x: ix.accounts[3].0.into(),
+                    user_token_y: ix.accounts[4].0.into(),
+                    reserve_x: ix.accounts[5].0.into(),
+                    reserve_y: ix.accounts[6].0.into(),
+                    token_x_mint: ix.accounts[7].0.into(),
+                    token_y_mint: ix.accounts[8].0.into(),
+                    bin_array_lower: ix.accounts[9].0.into(),
+                    bin_array_upper: ix.accounts[10].0.into(),
+                    sender: ix.accounts[11].0.into(),
+                    token_x_program: ix.accounts[12].0.into(),
+                    token_y_program: ix.accounts[13].0.into(),
+                    event_authority: ix.accounts[14].0.into(),
+                    program: ix.accounts[15].0.into(),
+                };
+                Ok(LbClmmProgramIx::RemoveAllLiquidity(ix_accounts))
+            }
             [61, 115, 52, 23, 46, 13, 31, 144] => {
                 check_min_accounts_req(accounts_len, 2)?;
                 let ix_accounts = TogglePairStatusIxAccounts {
@@ -563,6 +970,99 @@ impl InstructionParser {
                 let de_ix_data: SetActivationPointIxData =
                     BorshDeserialize::deserialize(&mut ix_data)?;
                 Ok(LbClmmProgramIx::SetActivationPoint(ix_accounts, de_ix_data))
+            }
+            [26, 82, 102, 152, 240, 74, 105, 26] => {
+                check_min_accounts_req(accounts_len, 16)?;
+                let ix_accounts = RemoveLiquidityByRangeIxAccounts {
+                    position: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    user_token_x: ix.accounts[3].0.into(),
+                    user_token_y: ix.accounts[4].0.into(),
+                    reserve_x: ix.accounts[5].0.into(),
+                    reserve_y: ix.accounts[6].0.into(),
+                    token_x_mint: ix.accounts[7].0.into(),
+                    token_y_mint: ix.accounts[8].0.into(),
+                    bin_array_lower: ix.accounts[9].0.into(),
+                    bin_array_upper: ix.accounts[10].0.into(),
+                    sender: ix.accounts[11].0.into(),
+                    token_x_program: ix.accounts[12].0.into(),
+                    token_y_program: ix.accounts[13].0.into(),
+                    event_authority: ix.accounts[14].0.into(),
+                    program: ix.accounts[15].0.into(),
+                };
+                let de_ix_data: RemoveLiquidityByRangeIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::RemoveLiquidityByRange(
+                    ix_accounts,
+                    de_ix_data,
+                ))
+            }
+            [161, 194, 103, 84, 171, 71, 250, 154] => {
+                check_min_accounts_req(accounts_len, 12)?;
+                let ix_accounts = AddLiquidityOneSidePreciseIxAccounts {
+                    position: ix.accounts[0].0.into(),
+                    lb_pair: ix.accounts[1].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    user_token: ix.accounts[3].0.into(),
+                    reserve: ix.accounts[4].0.into(),
+                    token_mint: ix.accounts[5].0.into(),
+                    bin_array_lower: ix.accounts[6].0.into(),
+                    bin_array_upper: ix.accounts[7].0.into(),
+                    sender: ix.accounts[8].0.into(),
+                    token_program: ix.accounts[9].0.into(),
+                    event_authority: ix.accounts[10].0.into(),
+                    program: ix.accounts[11].0.into(),
+                };
+                let de_ix_data: AddLiquidityOneSidePreciseIxData =
+                    BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::AddLiquidityOneSidePrecise(
+                    ix_accounts,
+                    de_ix_data,
+                ))
+            }
+            [146, 72, 174, 224, 40, 253, 84, 174] => {
+                check_min_accounts_req(accounts_len, 6)?;
+                let ix_accounts = GoToABinIxAccounts {
+                    lb_pair: ix.accounts[0].0.into(),
+                    bin_array_bitmap_extension: if ix.accounts[1]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[1].0.into())
+                    },
+                    from_bin_array: if ix.accounts[2]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[2].0.into())
+                    },
+                    to_bin_array: if ix.accounts[3]
+                        .eq(&yellowstone_vixen_core::KeyBytes::from(ID.to_bytes()))
+                    {
+                        None
+                    } else {
+                        Some(ix.accounts[3].0.into())
+                    },
+                    event_authority: ix.accounts[4].0.into(),
+                    program: ix.accounts[5].0.into(),
+                };
+                let de_ix_data: GoToABinIxData = BorshDeserialize::deserialize(&mut ix_data)?;
+                Ok(LbClmmProgramIx::GoToABin(ix_accounts, de_ix_data))
             }
             [165, 61, 201, 244, 130, 159, 22, 100] => {
                 check_min_accounts_req(accounts_len, 2)?;

--- a/packages/renderers-vixen-parser/e2e/test.sh
+++ b/packages/renderers-vixen-parser/e2e/test.sh
@@ -10,7 +10,7 @@ function test_project() {
 
 function test_anchor_project() {
     ./e2e/generate-anchor.cjs $1 $2 $3 
-    cd e2e/$1
+    cd e2e/$1/parser
     cargo check
     cd ../..
 }
@@ -18,3 +18,5 @@ test_project ./dummy_parser codama-renderers-rust-e2e-dummy true
 test_project ./system_parser codama-renderers-rust-e2e-system true
 test_project ./memo_parser codama-renderers-rust-e2e-memo true
 test_anchor_project ./anchor_parser codama-renderers-rust-e2e-anchor true
+
+test_anchor_project meteora codama-renderers-rust-e2e-meteora true

--- a/packages/renderers-vixen-parser/public/templates/CargoPage.njk
+++ b/packages/renderers-vixen-parser/public/templates/CargoPage.njk
@@ -2,19 +2,20 @@
 
 
 [package]
-name = "codama-renderers-vixen-parser-e2e-{{ projectName }}"
+name = "{{ projectName }}"
 version = "0.0.0"
 edition = "2021"
 
 
 [dependencies]
 prost = "0.13.1"
-prost-build = { version = "0.13.1"}
 yellowstone-vixen-core = { git = "https://github.com/rpcpool/yellowstone-vixen", branch = "main",features = ["proto"]}
 tonic = { version = "0.12.1", features = ["gzip", "zstd"] }
-codama-renderers-rust-e2e-{{ projectName }} = { path = "../../../../renderers-rust/e2e/{{ projectName }}" }
 solana-program = "^2.1.6"
 borsh = "^0.10"
+{% for dependency in additionalDependencies %}
+{{ dependency }}
+{% endfor %}
 
 
 

--- a/packages/renderers-vixen-parser/public/templates/libPage.njk
+++ b/packages/renderers-vixen-parser/public/templates/libPage.njk
@@ -1,10 +1,18 @@
 {% block main %}
 
+{% if overrided %}
+    {% for line in newContent %}
+        {{ line }}
+    {% endfor %}
+{% else %}
+
 mod generated;
 
 pub use generated::*;
 
 pub extern crate prost;
+
+{% endif %}
 
 // #[cfg(feature = "proto")]
 mod proto_def {

--- a/packages/renderers-vixen-parser/public/templates/proto.njk
+++ b/packages/renderers-vixen-parser/public/templates/proto.njk
@@ -24,4 +24,20 @@ package proto_def;
 {{ ix.args }}
 {% endfor %}
 
+message {{ programName | pascalCase }}ProgramState {
+  oneof state_oneof {
+    {% for account in programStateOneOf %}
+        {{ account }}
+    {% endfor %}
+  }
+}
+
+message {{ programName | pascalCase }}Ixs {
+  oneof ix_oneof {
+    {% for ix in programIxsOneOf %}
+        {{ ix }}
+    {% endfor %}
+  }
+}
+
 {% endblock %}

--- a/packages/renderers-vixen-parser/public/templates/protoHelpersPage.njk
+++ b/packages/renderers-vixen-parser/public/templates/protoHelpersPage.njk
@@ -1,0 +1,23 @@
+{% extends "layout.njk" %}
+
+{% import "macros.njk" as macros %}
+
+{% block main %}
+
+// #[cfg(feature = "proto")]
+mod proto_types_parsers {
+    {% for typeHelper in protoTypesHelpers %}
+        use super::{{ typeHelper.name | pascalCase }};
+        impl IntoProto<proto_def::{{ typeHelper.name | pascalCase }}> for {{ typeHelper.name | pascalCase }} {
+            fn into_proto(self) -> proto_def::{{ typeHelper.name | pascalCase }} {
+                proto_def::{{ typeHelper.name | pascalCase }} {
+                    {% for field in typeHelper.fields %}
+                        {{ field }}: self.{{ field }}{{ field.transform }},
+                    {% endfor %}
+                }
+            }
+        }   
+    {% endfor %}
+}
+
+{% endblock %}


### PR DESCRIPTION
- Add ProgramState & IXs `oneof` proto messages
- Remove prost-build from `dependencies`
- Allow full customization of package name for the crate and slot for additional dependencies
- Allow to customize folder structure and lib.rs imports, in order to support the folder structure used in Vixen repo parsers
- [WIP] implement transformers for into_proto() for idl `defined types`